### PR TITLE
Turn faq into collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,11 @@ While we have no announcements to share at this time, we hope you'll continue to
 
 ### Frequently Asked Questions
 
-*Q: I see an advertisement for an official/public server; should I play on this?*  
-A: There are no "official" LEGO Universe servers. The Darkflame Universe team does not endorse or recommend any servers that are open to the public. We recommend users either host their own server, as we discuss below, or join a private server hosted by friends/family.
-
-*Q: Where do I get your server software so I can play with my friends &amp; family?*  
-A: Our server software is available on [our official GitHub, DarkflameUniverse/DarkflameServer](https://github.com/DarkflameUniverse/DarkflameServer) and the setup process has been vastly improved since our initial release. We recommend [HailStorm32's setup guide](https://gist.github.com/HailStorm32/169df65a47a104199b5cc57d10fa57de) if using a Windows machine. If you still have questions, please utilize [our GitHub's discussion page](https://github.com/DarkflameUniverse/DarkflameServer/discussions/categories/q-a).
-
-*Q: Where do I get a LEGO Universe client?*  
-A: Unfortunately, we cannot provide a LEGO Universe client or offer any assistance here due to not owning the rights to the game client. If you played LEGO Universe when it was live and patched up to the final version, you can use that client.
-
-*Q: Can I use a LEGO Universe CD to play the game?*  
-A: The CD client cannot be used as it does not install the final version of the game that our server needs.
-
-*Q: How can I report a server or user that is misusing your software?*  
-A: If you find a server or user that is charging money for in-game rewards/any other benefit, disabling moderation/allowing inappropriate content or doing illegal activity, please report this to The LEGO Group using their [Compliance Line](https://www.lego.com/compliance-line). Please include as much information as possible and warn others to stay away from it if you see talk online about it.
+<dl class="faq">
+{% for faq in site.faqs %}
+<dt>{{ faq.question }}</dt><dd>{{ faq.content }}</dd>
+{% endfor %}
+</dl>
 
 This isn't the end of the Darkflame Team, Explorers.  
 LEGO Universe will live on forever thanks to our community, contributors and dedicated development team.

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,9 @@ theme: minima
 plugins:
   - jekyll-feed
 
+collections:
+  - faqs
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_faqs/01-public-servers.md
+++ b/_faqs/01-public-servers.md
@@ -1,0 +1,4 @@
+---
+question: I see an advertisement for an official/public server; should I play on this?
+---
+There are no "official" LEGO Universe servers. The Darkflame Universe team does not endorse or recommend any servers that are open to the public. We recommend users either host their own server, as we discuss below, or join a private server hosted by friends/family.

--- a/_faqs/02-server-software.md
+++ b/_faqs/02-server-software.md
@@ -1,0 +1,4 @@
+---
+question: Where do I get your server software so I can play with my friends &amp; family?
+---
+Our server software is available on [our official GitHub, DarkflameUniverse/DarkflameServer](https://github.com/DarkflameUniverse/DarkflameServer) and the setup process has been vastly improved since our initial release. We recommend [HailStorm32's setup guide](https://gist.github.com/HailStorm32/169df65a47a104199b5cc57d10fa57de) if using a Windows machine. If you still have questions, please utilize [our GitHub's discussion page](https://github.com/DarkflameUniverse/DarkflameServer/discussions/categories/q-a).

--- a/_faqs/03-client.md
+++ b/_faqs/03-client.md
@@ -1,0 +1,4 @@
+---
+question: Where do I get a LEGO Universe client?
+---
+Unfortunately, we cannot provide a LEGO Universe client or offer any assistance here due to not owning the rights to the game client. If you played LEGO Universe when it was live and patched up to the final version, you can use that client.

--- a/_faqs/04-cd-rom.md
+++ b/_faqs/04-cd-rom.md
@@ -1,0 +1,4 @@
+---
+question: Can I use a LEGO Universe CD to play the game?
+---
+The CD client cannot be used as it does not install the final version of the game that our server needs.

--- a/_faqs/06-report.md
+++ b/_faqs/06-report.md
@@ -1,0 +1,4 @@
+---
+question: How can I report a server or user that is misusing your software?
+---
+If you find a server or user that is charging money for in-game rewards/any other benefit, disabling moderation/allowing inappropriate content or doing illegal activity, please report this to The LEGO Group using their [Compliance Line](https://www.lego.com/compliance-line). Please include as much information as possible and warn others to stay away from it if you see talk online about it.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,18 @@
             margin-bottom: 24px;
         }
 
+        dl.faq > dt {
+            font-style: italic;
+        }
+        
+        dl.faq > dt::before {
+            content: "Q: ";
+        }
+        
+        dl.faq > dd > p:first-of-type::before {
+            content: "A: ";
+        }
+
         .logo {
             width: 9vw;
         }


### PR DESCRIPTION
This turns FAQ into a collection of individual markdown files, so we can easily add more without paying attention to the details of the formatting. The `question` needs to be specified in YAML frontmatter, the answer is the `content`.

HTML structures has been changed to a definition list, the visual appearance is unchanged. Order is unchanged, but I skipped `05` for a follow-up on licensing.